### PR TITLE
fix replacing liboneandone with liboneandone-2 with updated mocha dep…

### DIFF
--- a/lib/pkgcloud/oneandone/blockstorage/client/snapshots.js
+++ b/lib/pkgcloud/oneandone/blockstorage/client/snapshots.js
@@ -3,7 +3,7 @@
  */
 
 var Snapshot = require('../snapshot').Snapshot,
-  oneandone = require('liboneandone'),
+  oneandone = require('liboneandone-2'),
   Server = require('../../compute/server').Server;
 /**
  * client.getSnapshots

--- a/lib/pkgcloud/oneandone/client.js
+++ b/lib/pkgcloud/oneandone/client.js
@@ -5,7 +5,7 @@
  */
 
 var util = require('util'),
-  OAO = require('liboneandone'),
+  OAO = require('liboneandone-2'),
   url = 'cloudpanel-api.1and1.com/v1',
   base = require('../core/base');
 

--- a/lib/pkgcloud/oneandone/compute/client/flavors.js
+++ b/lib/pkgcloud/oneandone/compute/client/flavors.js
@@ -4,7 +4,7 @@
 
 var pkgcloud = require('../../../../../lib/pkgcloud'),
   base = require('../../../core/compute'),
-  oneandone = require('liboneandone'),
+  oneandone = require('liboneandone-2'),
   compute = pkgcloud.providers.oneandone.compute;
 
 //

--- a/lib/pkgcloud/oneandone/compute/client/images.js
+++ b/lib/pkgcloud/oneandone/compute/client/images.js
@@ -4,7 +4,7 @@
  */
 var pkgcloud = require('../../../../../lib/pkgcloud'),
   base = require('../../../core/compute'),
-  oneandone = require('liboneandone'),
+  oneandone = require('liboneandone-2'),
   compute = pkgcloud.providers.oneandone.compute;
 //
 // ### function getImages (callback)

--- a/lib/pkgcloud/oneandone/compute/client/servers.js
+++ b/lib/pkgcloud/oneandone/compute/client/servers.js
@@ -5,7 +5,7 @@
 var base = require('../../../core/compute'),
   pkgcloud = require('../../../../../lib/pkgcloud'),
   errs = require('errs'),
-  oneandone = require('liboneandone'),
+  oneandone = require('liboneandone-2'),
   compute = pkgcloud.providers.oneandone.compute;
 
 //

--- a/lib/pkgcloud/oneandone/loadbalancer/client/loadbalancers.js
+++ b/lib/pkgcloud/oneandone/loadbalancer/client/loadbalancers.js
@@ -1,7 +1,7 @@
 /**
  * Created by Ali Bazlamit on 8/31/2017.
  */
-var oneandone = require('liboneandone'),
+var oneandone = require('liboneandone-2'),
   LoadBalancer = require('../loadbalancer').LoadBalancer;
 
 //

--- a/lib/pkgcloud/oneandone/loadbalancer/client/nodes.js
+++ b/lib/pkgcloud/oneandone/loadbalancer/client/nodes.js
@@ -1,7 +1,7 @@
 /**
  * Created by Ali Bazlamit on 8/31/2017.
  */
-var oneandone = require('liboneandone'),
+var oneandone = require('liboneandone-2'),
   LoadBalancer = require('../loadbalancer').LoadBalancer,
   Node = require('../node').Node;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -617,11 +617,6 @@
         "delayed-stream": "~1.0.0"
       }
     },
-    "commander": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
-      "integrity": "sha512-CD452fnk0jQyk3NfnK+KkR/hUPoHt5pVaKHogtyyv3N0U4QfAal9W0/rXLOg/vVZgQKa7jdtXypKs1YAip11uQ=="
-    },
     "compressible": {
       "version": "2.0.18",
       "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
@@ -752,11 +747,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
-    },
-    "diff": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
-      "integrity": "sha512-VzVc42hMZbYU9Sx/ltb7KYuQ6pqAw+cbFWVy4XKdkuEL2CFaRLGEnISPs7YdzaUGpi+CpIqvRmu7hPQ4T7EQ5w=="
     },
     "dom-serializer": {
       "version": "0.2.2",
@@ -948,11 +938,6 @@
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
       }
-    },
-    "escape-string-regexp": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
-      "integrity": "sha512-cQpUid7bdTUnFin8S7BnNdOk+/eDqQmKgCANSyd/jAhrKEvxUvr9VQ8XZzXiOtest8NLfk3FSBZzwvemZNQ6Vg=="
     },
     "esprima": {
       "version": "4.0.1",
@@ -1211,15 +1196,6 @@
         "assert-plus": "^1.0.0"
       }
     },
-    "glob": {
-      "version": "3.2.11",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
-      "integrity": "sha512-hVb0zwEZwC1FXSKRPFTeOtN7AArJcJlI6ULGLtrstaswKNlrTJqAA+1lYlSUop4vjA423xlBzqfVS3iWGlqJ+g==",
-      "requires": {
-        "inherits": "2",
-        "minimatch": "0.3"
-      }
-    },
     "globals": {
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
@@ -1273,11 +1249,6 @@
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
       "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
-    },
-    "growl": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
-      "integrity": "sha512-RTBwDHhNuOx4F0hqzItc/siXCasGfC4DeWcBamclWd+6jWtBaeB/SGbMkGf0eiQoW7ib8JpvOgnUsmgMHI3Mfw=="
     },
     "gtoken": {
       "version": "5.3.2",
@@ -1663,27 +1634,6 @@
         "semver": "^6.0.0"
       }
     },
-    "jade": {
-      "version": "0.26.3",
-      "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
-      "integrity": "sha512-mkk3vzUHFjzKjpCXeu+IjXeZD+QOTjUUdubgmHtHTDwvAO2ZTkMTTVrapts5CWz3JvJryh/4KWZpjeZrCepZ3A==",
-      "requires": {
-        "commander": "0.6.1",
-        "mkdirp": "0.3.0"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
-          "integrity": "sha512-0fLycpl1UMTGX257hRsu/arL/cUbcvQM4zMKwvLvzXtfdezIV4yotPS2dYtknF+NmEfWSoCEF6+hj9XLm/6hEw=="
-        },
-        "mkdirp": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
-          "integrity": "sha512-OHsdUcVAQ6pOtg5JYWpCBo9W/GySVuwvP9hueRMW7UqshC0tbfzLv8wjySTPm3tfUZ/21CE9E1pJagOA91Pxew=="
-        }
-      }
-    },
     "jmespath": {
       "version": "0.16.0",
       "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
@@ -1801,45 +1751,12 @@
       "integrity": "sha512-aprLII/vPzuQvYZnDRU78Fns9I2Ag3gi4Ipga/hxnVMCZC8DnR2nI7XBqrPoywGfxqIx/DgarGvDJZAD3YBTgQ==",
       "dev": true
     },
-    "liboneandone": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/liboneandone/-/liboneandone-1.2.0.tgz",
-      "integrity": "sha512-EB6Ak9qw+U4HAOnKqPtatxQ9pLclvtsBsggrvOuD4zclJ5xOeEASojsLKEC3O8KJ1Q4obE2JHhOeDuqWXvkoUQ==",
+    "liboneandone-2": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/liboneandone-2/-/liboneandone-2-1.0.0.tgz",
+      "integrity": "sha512-tILYm7wGWLlBRVtlQUrrrpui8orjhSoG8oR3cevFKbQJpjLbWFuZ4N0cUYJT/1usn3zyYMxN6JtdlmDXPY/agw==",
       "requires": {
-        "mocha": "^2.5.3",
-        "request": "^2.74.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha512-X0rGvJcskG1c3TgSCPqHJ0XJgwlcvOC7elJ5Y0hYuKBZoVqWpAMfLOeIh2UI/DCQ5ruodIjvsugZtjUYUw2pUw==",
-          "requires": {
-            "ms": "0.7.1"
-          }
-        },
-        "mocha": {
-          "version": "2.5.3",
-          "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.5.3.tgz",
-          "integrity": "sha512-jNt2iEk9FPmZLzL+sm4FNyOIDYXf2wUU6L4Cc8OIKK/kzgMHKPi4YhTZqG4bW4kQVdIv6wutDybRhXfdnujA1Q==",
-          "requires": {
-            "commander": "2.3.0",
-            "debug": "2.2.0",
-            "diff": "1.4.0",
-            "escape-string-regexp": "1.0.2",
-            "glob": "3.2.11",
-            "growl": "1.9.2",
-            "jade": "0.26.3",
-            "mkdirp": "0.5.1",
-            "supports-color": "1.2.0",
-            "to-iso-string": "0.0.2"
-          }
-        },
-        "ms": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-          "integrity": "sha512-lRLiIR9fSNpnP6TC4v8+4OU7oStC01esuNowdQ34L+Gk8e5Puoc88IqJ+XAY/B3Mn2ZKis8l8HX90oU8ivzUHg=="
-        }
+        "request": "^2.88.0"
       }
     },
     "locate-path": {
@@ -1910,35 +1827,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
-    },
-    "minimatch": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
-      "integrity": "sha512-WFX1jI1AaxNTZVOHLBVazwTWKaQjoykSzCBNXB72vDTCzopQGtyP91tKdFK5cv1+qMwPyiTu1HqUriqplI8pcA==",
-      "requires": {
-        "lru-cache": "2",
-        "sigmund": "~1.0.0"
-      },
-      "dependencies": {
-        "lru-cache": {
-          "version": "2.7.3",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-          "integrity": "sha512-WpibWJ60c3AgAz8a2iYErDrcT2C7OmKnsWhIcHOjkUHFjkXncJhtLxNSqUmxRxRunpb5I8Vprd7aNSd2NtksJQ=="
-        }
-      }
-    },
-    "minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha512-miQKw5Hv4NS1Psg2517mV4e4dYNaO3++hjAvLOAzKqZ61rH8NS1SK+vbfBWZ5PY/Me/bEWhUwqMghEW5Fb9T7Q=="
-    },
-    "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha512-SknJC52obPfGQPnjIkXbmA6+5H15E+fR+E4iR2oQ3zzCLbd7/ONua69R/Gw7AgkTLsRG+r5fzksYwWe1AgTyWA==",
-      "requires": {
-        "minimist": "0.0.8"
-      }
     },
     "mocha": {
       "version": "6.2.3",
@@ -3489,11 +3377,6 @@
         "object-inspect": "^1.9.0"
       }
     },
-    "sigmund": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-      "integrity": "sha512-fCvEXfh6NWpm+YSuY2bpXb/VIihqWA6hLsgboC+0nl71Q7N7o2eaCW8mJa/NLvQhs6jpd3VZV4UiUQlV6+lc8g=="
-    },
     "signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -3597,11 +3480,6 @@
       "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
       "integrity": "sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw=="
     },
-    "supports-color": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz",
-      "integrity": "sha512-mS5xsnjTh5b7f2DM6bch6lR582UCOTphzINlZnDsfpIRrwI6r58rb6YSSGsdexkm8qw2bBVO2ID2fnJOTuLiPA=="
-    },
     "teeny-request": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-7.2.0.tgz",
@@ -3628,11 +3506,6 @@
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
       "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
       "dev": true
-    },
-    "to-iso-string": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/to-iso-string/-/to-iso-string-0.0.2.tgz",
-      "integrity": "sha512-oeHLgfWA7d0CPQa6h0+i5DAJZISz5un0d5SHPkw+Untclcvzv9T+AC3CvGXlZJdOlIbxbTfyyzlqCXc5hjpXYg=="
     },
     "tough-cookie": {
       "version": "2.5.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "fast-json-patch": "^2.1.0",
     "filed-mimefix": "^0.1.3",
     "ip": "^1.1.5",
-    "liboneandone": "^1.2.0",
+    "liboneandone-2": "^1.0.0",
     "lodash": "^4.17.10",
     "mime": "^2.4.1",
     "qs": "^6.5.2",

--- a/test/oneandone/loadbalancer/test-loadbalancers.js
+++ b/test/oneandone/loadbalancer/test-loadbalancers.js
@@ -10,7 +10,7 @@ var should = require('should'),
   hock = require('hock'),
   http = require('http'),
   mock = !!process.env.MOCK,
-  oneandone = require('liboneandone'),
+  oneandone = require('liboneandone-2'),
   LoadBalancer = require('../../../lib/pkgcloud/oneandone/loadbalancer/loadbalancer').LoadBalancer,
   Node = require('../../../lib/pkgcloud/oneandone/loadbalancer/node').Node;
 


### PR DESCRIPTION
参考：https://github.com/pkgcloud/pkgcloud/pull/681/commits

[liboneandone-2](https://www.npmjs.com/package/liboneandone-2) is a fork of the [liboneandone](https://www.npmjs.com/package/liboneandone)